### PR TITLE
Fix React Native Web text node rendering error

### DIFF
--- a/MyRecipeApp/App.js
+++ b/MyRecipeApp/App.js
@@ -1219,9 +1219,9 @@ export default function App() {
                   <Text style={styles.categoryBadgeText}>{item.category || 'Dinner'}</Text>
                 </View>
                 <View style={styles.recipeMetadata}>
-                  {item.prepTime && <Text style={styles.timeText}>⏱️ {item.prepTime}</Text>}
-                  {item.cookTime && <Text style={styles.timeText}>🔥 {item.cookTime}</Text>}
-                  {item.videoUrl && <Text style={styles.videoIndicator}>🎥</Text>}
+                  {item.prepTime ? <Text style={styles.timeText}>⏱️ {item.prepTime}</Text> : null}
+                  {item.cookTime ? <Text style={styles.timeText}>🔥 {item.cookTime}</Text> : null}
+                  {item.videoUrl ? <Text style={styles.videoIndicator}>🎥</Text> : null}
                 </View>
               </View>
             </TouchableOpacity>


### PR DESCRIPTION
## Summary
Fixes #33

This PR resolves a React Native Web rendering error that was causing the web app to crash with the error:
```
Unexpected text node: . A text node cannot be a child of a <View>.
```

## Root Cause
The issue occurred because of conditional rendering using `&&` operator with string values:
```javascript
{item.prepTime && <Text>⏱️ {item.prepTime}</Text>}
```

When `item.prepTime` is an empty string `""`, the expression evaluates to `""` (a falsy but renderable value), which React Native Web interprets as a text node being placed inside a View - which is not allowed.

## Solution
Changed from `&&` to ternary operator with explicit `null` return:
```javascript
{item.prepTime ? <Text>⏱️ {item.prepTime}</Text> : null}
```

This ensures that when the value is empty/falsy, `null` is returned instead of an empty string.

## Changes
- Fixed conditional rendering for `prepTime` in recipe metadata
- Fixed conditional rendering for `cookTime` in recipe metadata  
- Fixed conditional rendering for `videoUrl` in recipe metadata

## Testing
- All 33 unit tests pass
- Security audit passes with 0 vulnerabilities