### PR TITLE
docs: add Android keystore generation and setup documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,51 @@
+# Secrets and sensitive files
+*.keystore
+*.jks
+*.key
+.env
+.env.local
+.env.*.local
+
+# Credentials and tokens
+KEYSTORE_PASSWORD.txt
+credentials.json
+
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Testing
+coverage/
+.jest/
+
+# Build outputs
+build/
+dist/
+*.apk
+*.aab
+
+# Expo
+.expo/
+.expo-shared/
+dist/
+npm-debug.*
+*.jks
+*.p8
+*.p12
+*.key
+*.mobileprovision
+*.orig.*
+web-build/
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# OS
+Thumbs.db
+.DS_Store

--- a/docs/KEYSTORE_SETUP.md
+++ b/docs/KEYSTORE_SETUP.md
@@ -1,0 +1,157 @@
+# Android Keystore Setup Guide
+
+## Overview
+This document describes the Android keystore setup for signing production APK builds for Google Play Store submission.
+
+## What is a Keystore?
+A keystore is a binary file that contains cryptographic keys used to digitally sign your Android APK. Google Play requires all apps to be signed with the same key throughout their lifetime.
+
+## Keystore Security ⚠️
+
+**The keystore file and its password are CRITICAL secrets. Protect them at all costs:**
+- Never commit the keystore to version control
+- Never share the keystore file or passwords publicly
+- Store passwords in a secure location (password manager, 1Password, LastPass, etc.)
+- For CI/CD: Use GitHub Secrets to store keystore credentials
+
+The keystore is added to `.gitignore` and will NOT be committed to the repository.
+
+## Generating the Keystore
+
+### Option 1: Using the Script (Automated)
+
+```bash
+# Edit the script with your preferred passwords
+nano scripts/generate-keystore.sh
+
+# Make the script executable and run it
+chmod +x scripts/generate-keystore.sh
+./scripts/generate-keystore.sh
+```
+
+### Option 2: Manual Command
+
+```bash
+keytool -genkey -v \
+  -keystore cooking_app_release.keystore \
+  -keyalg RSA \
+  -keysize 2048 \
+  -validity 10000 \
+  -alias cooking_app_key \
+  -storepass your_secure_password_here \
+  -keypass your_secure_password_here \
+  -dname "CN=MyRecipeApp, O=CookingApp, L=Cupertino, ST=California, C=US"
+```
+
+## Keystore Location
+
+After generation, the keystore should be placed in:
+```
+MyRecipeApp/cooking_app_release.keystore
+```
+
+The file will be ignored by Git (see `.gitignore`).
+
+## Keystore Credentials
+
+**Save these securely (use password manager):**
+- Keystore File: `cooking_app_release.keystore`
+- Keystore Password: `[your_secure_password]`
+- Key Alias: `cooking_app_key`
+- Key Password: `[your_secure_password]`
+- Validity: 10000 days (~27 years)
+- Algorithm: RSA (2048-bit)
+
+## Verifying the Keystore
+
+To verify the keystore was created correctly:
+
+```bash
+# List keystore contents
+keytool -list -v -keystore cooking_app_release.keystore -storepass your_password
+
+# Expected output should show:
+# - Alias: cooking_app_key
+# - Key type: RSA
+# - Certificate Fingerprints: SHA1, SHA256, MD5
+```
+
+## Using the Keystore for Builds
+
+### Local Development Builds
+
+To build a signed APK for testing locally:
+
+```bash
+cd MyRecipeApp
+
+# Build release APK with signing
+eas build --platform android --type release \
+  --local \
+  --keystore cooking_app_release.keystore \
+  --keystore-password your_password \
+  --key-alias cooking_app_key \
+  --key-password your_password
+```
+
+### CI/CD Integration (GitHub Actions)
+
+For automatic builds in CI/CD, store secrets in GitHub:
+
+1. Go to repository Settings → Secrets and variables → Actions
+2. Create secrets:
+   - `KEYSTORE_PASSWORD`: Your keystore password
+   - `KEY_PASSWORD`: Your key password
+   - `KEY_ALIAS`: cooking_app_key
+
+Then reference in GitHub Actions workflows.
+
+## Backup & Recovery
+
+**IMPORTANT:** Backup your keystore file securely!
+
+If you lose the keystore or passwords, you'll need to generate a new key and cannot update the existing Play Store app. You would need to:
+1. Create a new app listing on Google Play
+2. Use a different package name
+3. Essentially create a new app
+
+**Backup process:**
+```bash
+# Make secure backups
+cp cooking_app_release.keystore ~/backups/
+# Store password in password manager
+# Document keystore creation date and validity expiration (10000 days from creation)
+```
+
+## Certificate Expiration
+
+The generated certificate is valid for 10000 days (~27 years), which exceeds Google Play's requirement of 25+ years validity.
+
+**Do NOT generate a new keystore** - use the same one for all future updates to the same app!
+
+## Troubleshooting
+
+### "keytool: command not found"
+You need to install Java Development Kit (JDK):
+```bash
+# macOS
+brew install openjdk
+
+# Ubuntu/Debian
+sudo apt-get install default-jdk
+
+# Windows
+Download from: https://www.oracle.com/java/technologies/downloads/
+```
+
+### "Certificate fingerprint" mismatch in Play Store
+Ensure you're using the exact same keystore and passwords for all builds. The fingerprint must match what's registered in Play Console.
+
+### "Invalid keystore format"
+The keystore file may be corrupted. Regenerate it using the script above.
+
+## Additional Resources
+
+- [Android Signing Documentation](https://developer.android.com/studio/publish/app-signing)
+- [Google Play: App Signing](https://play.google.com/console/about/guides/app-signing/)
+- [Expo: Building with EAS](https://docs.expo.dev/build/setup/)

--- a/scripts/generate-keystore.sh
+++ b/scripts/generate-keystore.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Android Keystore Generation Script for MyRecipeApp
+# This script generates a signing keystore for production Android APK builds
+# Required for Google Play Store submission
+
+set -e
+
+KEYSTORE_FILE="cooking_app_release.keystore"
+KEYSTORE_ALIAS="cooking_app_key"
+KEYSTORE_PASSWORD="Myfirstappforfreedom@84"  # ⚠️ CHANGE THIS TO A STRONG PASSWORD
+KEY_PASSWORD="Myfirstappforfreedom@84"       # ⚠️ CHANGE THIS TO A STRONG PASSWORD
+VALIDITY_DAYS=10000
+KEY_SIZE=2048
+
+echo "🔑 Generating Android Signing Keystore for MyRecipeApp"
+echo "=================================================="
+echo ""
+echo "⚠️  IMPORTANT: Update passwords in this script before running!"
+echo "   Keystore file: $KEYSTORE_FILE"
+echo "   Alias: $KEYSTORE_ALIAS"
+echo "   Validity: $VALIDITY_DAYS days"
+echo ""
+
+# Generate keystore using keytool
+keytool -genkey -v \
+  -keystore "$KEYSTORE_FILE" \
+  -keyalg RSA \
+  -keysize "$KEY_SIZE" \
+  -validity "$VALIDITY_DAYS" \
+  -alias "$KEYSTORE_ALIAS" \
+  -storepass "$KEYSTORE_PASSWORD" \
+  -keypass "$KEY_PASSWORD" \
+  -dname "CN=MyRecipeApp, O=CookingApp, L=Cupertino, ST=California, C=US"
+
+if [ -f "$KEYSTORE_FILE" ]; then
+  echo ""
+  echo "✅ Keystore generated successfully!"
+  echo "   File: $KEYSTORE_FILE"
+  echo ""
+  echo "📝 Save these credentials securely:"
+  echo "   Keystore Password: $KEYSTORE_PASSWORD"
+  echo "   Key Password: $KEY_PASSWORD"
+  echo "   Alias: $KEYSTORE_ALIAS"
+  echo ""
+  echo "⚠️  SECURITY: Store passwords in a secure location (password manager, CI/CD secrets, etc.)"
+else
+  echo "❌ Failed to generate keystore"
+  exit 1
+fi


### PR DESCRIPTION
Create Android signing keystore and setup documentation for Play Store release.

## Changes
- Add `scripts/generate-keystore.sh` for automated keystore generation
- Add comprehensive `docs/KEYSTORE_SETUP.md` with security best practices
- Update `.gitignore` to exclude keystore files and sensitive credentials
- Keystore generated with RSA-2048, valid for 10000 days (~27 years)

## Security
- ✅ Keystore file excluded from version control (added to .gitignore)
- ✅ Documentation includes password manager recommendations
- ✅ Setup guide covers backup and recovery procedures
- ✅ Certificate fingerprint verification steps documented

## What's Included
- Automated keystore generation script with strong RSA-2048 encryption
- Complete setup and troubleshooting guide
- CI/CD integration instructions for GitHub Secrets
- Security best practices and credential management

Closes #46