### PR TITLE
docs: add graphics specifications and placeholder generation script

### DIFF
--- a/graphics/GRAPHICS_SPECIFICATIONS.md
+++ b/graphics/GRAPHICS_SPECIFICATIONS.md
@@ -1,0 +1,214 @@
+# Google Play Store Graphics Requirements
+
+## Overview
+
+This document specifies the graphics and visual assets required for the Google Play Store listing.
+
+## Required Graphics
+
+### 1. App Icon (512 × 512 px)
+
+**Specifications:**
+- Dimensions: 512 × 512 pixels
+- Format: PNG (transparent background) or JPEG
+- File size: < 1 MB
+- Safe area: Keep important content within inner 72 × 72 px square
+- No text/branding text should be included
+- Must be unique and distinguishable from other icons
+
+**Design Guidelines:**
+- Use MyRecipeApp brand colors (recommend: recipe-related colors - warm oranges, greens)
+- Include recognizable cooking/recipe symbol
+- Ensure clarity at small sizes (app drawer icon at 48×48 px)
+- High contrast for visibility
+
+**File to Upload:**
+- `graphics/app_icon_512x512.png`
+
+### 2. Feature Graphic (1024 × 500 px)
+
+**Specifications:**
+- Dimensions: 1024 × 500 pixels (landscape)
+- Format: PNG or JPEG
+- File size: < 1 MB
+- Safe area: Keep important content 80 px away from edges
+- NO app icon in the center
+- Can include text and branding
+
+**Design Guidelines:**
+- Eye-catching headline text (e.g., "AI Recipe Extraction")
+- Show key app features
+- Use brand colors
+- Professional, modern design
+- Communicates app value proposition
+- No app store badges or version numbers
+
+**File to Upload:**
+- `graphics/feature_graphic_1024x500.png`
+
+### 3. Screenshots (Multiple - Required)
+
+**Specifications:**
+- Minimum: 2 screenshots (Recommended: 3-5)
+- Dimensions: 
+  - **Phone (preferred):** 1080 × 1920 px or 1440 × 2560 px
+  - **Tablet:** 1024 × 768 px or 1024 × 1024 px
+- Format: PNG or JPEG
+- File size: < 1 MB each
+- Aspect ratio: Maintain device screen ratio
+
+**Requirements:**
+- No app icon or ratings in screenshots
+- Can include text overlays (optional)
+- Should show app UI and features
+- Portrait orientation for phones
+
+**Recommended Screenshots:**
+
+**Screenshot 1: Main Screen - Recipe Extraction**
+- Show: Recipe extraction interface
+- Text overlay: "AI-Powered Recipe Extraction"
+- Feature: Recipe input and extraction functionality
+- File: `graphics/screenshot_1_extraction_1080x1920.png`
+
+**Screenshot 2: Multi-Timer Feature**
+- Show: Multi-timer widget with multiple timers running
+- Text overlay: "Multi-Timer Widget"
+- Feature: Multiple active timers with labels
+- File: `graphics/screenshot_2_timer_1080x1920.png`
+
+**Screenshot 3: Recipe Management (Optional)**
+- Show: Recipe list/saved recipes
+- Text overlay: "Organize Your Recipes"
+- Feature: Recipe collection and management
+- File: `graphics/screenshot_3_recipes_1080x1920.png`
+
+**Screenshot 4: Privacy & Security (Optional)**
+- Show: Settings or privacy info
+- Text overlay: "Your Data, Your Control"
+- Feature: Privacy-first approach
+- File: `graphics/screenshot_4_privacy_1080x1920.png`
+
+## Color Palette (Recommended)
+
+**Primary Colors:**
+- Primary Orange: #FF6B35 (warm, cooking-related)
+- Primary Green: #004E89 (fresh ingredients)
+- Accent Blue: #1A7F7F (trustworthy)
+
+**Secondary Colors:**
+- Light Orange: #FFE66D (highlight)
+- Light Gray: #F5F5F5 (background)
+- Dark Gray: #333333 (text)
+
+## Typography
+
+**Font Recommendations:**
+- Primary font: Roboto or Open Sans (modern, readable)
+- Size: 24-48 pt for headlines, 16-20 pt for body text
+- Weight: Bold for headlines, Regular for body text
+
+## Creating Graphics
+
+### Option 1: DIY Using Design Tools
+
+**Tools:**
+- **Canva** (free/paid) - https://www.canva.com
+  - Has Play Store templates
+  - Easy drag-and-drop
+  - Large asset library
+- **Figma** (free/paid) - https://www.figma.com
+  - Professional design tool
+  - Collaborative
+- **Adobe XD** (free/paid)
+- **GIMP** (free, open-source)
+- **Photoshop** (paid)
+
+**Steps:**
+1. Open tool and create new project
+2. Set dimensions per specifications above
+3. Design icon, feature graphic, and screenshots
+4. Export as PNG with transparent background
+5. Save to `graphics/` directory
+
+### Option 2: Hire Designer
+
+- Fiverr, Upwork, 99designs
+- Cost: $50-500+ depending on requirements
+- Time: 3-7 days
+
+### Option 3: Use Placeholder Graphics (Automated)
+
+A Python script is provided: `generate_graphics.py`
+
+```bash
+# Install dependencies
+pip install Pillow
+
+# Generate placeholder graphics
+python graphics/generate_graphics.py
+```
+
+This creates:
+- `app_icon_512x512.png` - Placeholder icon
+- `feature_graphic_1024x500.png` - Feature banner
+- `screenshot_1_extraction_1080x1920.png` - Sample screenshots
+- `screenshot_2_timer_1080x1920.png`
+- `screenshot_3_recipes_1080x1920.png`
+
+**Note:** Placeholder graphics are for testing only. Use professional designs for actual Play Store submission.
+
+## File Organization
+
+```
+graphics/
+├── README.md (this file)
+├── generate_graphics.py (placeholder generator)
+├── app_icon_512x512.png
+├── feature_graphic_1024x500.png
+├── screenshot_1_extraction_1080x1920.png
+├── screenshot_2_timer_1080x1920.png
+├── screenshot_3_recipes_1080x1920.png
+└── screenshot_4_privacy_1080x1920.png (optional)
+```
+
+## Quality Checklist
+
+- [ ] Icon is 512×512 px PNG
+- [ ] Icon has no text overlay
+- [ ] Icon is unique and distinguishable
+- [ ] Feature graphic is 1024×500 px
+- [ ] Feature graphic has compelling headline
+- [ ] Screenshots are 1080×1920 px or 1440×2560 px
+- [ ] Screenshots are in portrait orientation
+- [ ] All graphics are < 1 MB each
+- [ ] Graphics have good contrast and readability
+- [ ] Graphics use consistent branding/colors
+- [ ] Graphics don't include ratings or badges
+- [ ] All graphics saved as PNG or JPEG
+
+## Uploading to Play Store
+
+1. Go to **Google Play Console**
+2. Select **MyRecipeApp**
+3. Go to **App content** → **Graphic assets**
+4. **Icon:** Upload `app_icon_512x512.png`
+5. **Feature graphic:** Upload `feature_graphic_1024x500.png`
+6. **Screenshots:** Upload 2-5 screenshots
+7. Click **Save**
+
+## Resources
+
+- **Play Store Graphics Guide:** https://support.google.com/googleplay/android-developer/answer/9866151
+- **Design Guidelines:** https://material.io/design
+- **Canva Play Store Templates:** https://www.canva.com/create/google-play-store-apps/
+- **App Store Optimization:** https://www.appacademy.com/aso-guide/
+
+---
+
+**Next Steps:**
+1. Generate or create graphics
+2. Place in `graphics/` directory
+3. Commit to repository
+4. Update Issue #50 status
+5. Ready for Play Store submission in Issue #52

--- a/graphics/README.md
+++ b/graphics/README.md
@@ -1,0 +1,80 @@
+# MyRecipeApp - Graphics Directory
+
+This directory contains graphics assets for Google Play Store submission.
+
+## Files
+
+- **GRAPHICS_SPECIFICATIONS.md** - Detailed requirements and design guidelines
+- **generate_graphics.py** - Python script to generate placeholder graphics
+- **app_icon_512x512.png** - App icon for Play Store
+- **feature_graphic_1024x500.png** - Feature banner graphic
+- **screenshot_*.png** - App screenshots for Play Store listing
+
+## Quick Start
+
+### Generate Placeholder Graphics
+
+```bash
+# Install dependencies (if needed)
+pip install Pillow
+
+# Generate all graphics
+python graphics/generate_graphics.py
+```
+
+This creates:
+- 512×512 px app icon
+- 1024×500 px feature graphic
+- 3 screenshots (1080×1920 px each)
+
+**Note:** These are placeholders for testing. Use professional designs for actual submission.
+
+### Use Professional Graphics
+
+For production submission to Play Store:
+
+1. **Design tools:** Canva, Figma, Adobe XD, or hire a designer
+2. **Follow specifications** in GRAPHICS_SPECIFICATIONS.md
+3. **Save to this directory**
+4. **Upload to Play Console**
+
+## Graphics Specifications
+
+See **GRAPHICS_SPECIFICATIONS.md** for:
+- Exact dimensions and file formats
+- Design guidelines and best practices
+- Color palette recommendations
+- Typography suggestions
+- Uploading instructions
+- Quality checklist
+
+## File Organization
+
+```
+graphics/
+├── README.md (this file)
+├── GRAPHICS_SPECIFICATIONS.md
+├── generate_graphics.py
+├── app_icon_512x512.png
+├── feature_graphic_1024x500.png
+├── screenshot_1_extraction_1080x1920.png
+├── screenshot_2_timer_1080x1920.png
+└── screenshot_3_recipes_1080x1920.png
+```
+
+## Next Steps
+
+1. **Generate or create graphics** (see above)
+2. **Review against specifications** (GRAPHICS_SPECIFICATIONS.md)
+3. **Commit to repository**
+4. **Upload to Play Console** (Issue #52)
+
+## Resources
+
+- Play Store Graphics Guide: https://support.google.com/googleplay/android-developer/answer/9866151
+- Canva (free templates): https://www.canva.com
+- Material Design: https://material.io/design
+
+---
+
+**Part of:** Issue #50 - Create app icons and graphics for Play Store

--- a/graphics/generate_graphics.py
+++ b/graphics/generate_graphics.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Google Play Store Graphics Generator
+
+Generates placeholder graphics for MyRecipeApp Play Store listing.
+This script creates:
+- App icon (512x512)
+- Feature graphic (1024x500)
+- Screenshots (1080x1920)
+
+Usage:
+    python graphics/generate_graphics.py
+
+Output:
+    graphics/app_icon_512x512.png
+    graphics/feature_graphic_1024x500.png
+    graphics/screenshot_*.png
+
+Note:
+    These are placeholder graphics for testing/development.
+    Use professional designs for actual Play Store submission.
+"""
+
+from PIL import Image, ImageDraw, ImageFont
+import os
+
+# Create graphics directory if it doesn't exist
+os.makedirs('graphics', exist_ok=True)
+
+# Brand colors
+COLOR_PRIMARY_ORANGE = (255, 107, 53)  # #FF6B35
+COLOR_PRIMARY_GREEN = (0, 78, 137)     # #004E89
+COLOR_ACCENT_BLUE = (26, 127, 127)     # #1A7F7F
+COLOR_LIGHT_ORANGE = (255, 230, 109)   # #FFE66D
+COLOR_LIGHT_GRAY = (245, 245, 245)     # #F5F5F5
+COLOR_DARK_GRAY = (51, 51, 51)         # #333333
+COLOR_WHITE = (255, 255, 255)
+
+def draw_rounded_rectangle(draw, xy, radius=20, fill=None, outline=None, width=1):
+    """Draw a rounded rectangle."""
+    x1, y1, x2, y2 = xy
+    draw.rectangle([x1+radius, y1, x2-radius, y2], fill=fill, outline=outline, width=width)
+    draw.rectangle([x1, y1+radius, x2, y2-radius], fill=fill, outline=outline, width=width)
+    draw.ellipse([x1, y1, x1+radius*2, y1+radius*2], fill=fill, outline=outline, width=width)
+    draw.ellipse([x2-radius*2, y1, x2, y1+radius*2], fill=fill, outline=outline, width=width)
+    draw.ellipse([x1, y2-radius*2, x1+radius*2, y2], fill=fill, outline=outline, width=width)
+    draw.ellipse([x2-radius*2, y2-radius*2, x2, y2], fill=fill, outline=outline, width=width)
+
+def generate_app_icon():
+    """Generate app icon 512x512."""
+    img = Image.new('RGBA', (512, 512), COLOR_WHITE)
+    draw = ImageDraw.Draw(img)
+    
+    # Background gradient effect with circles
+    draw.ellipse([0, 0, 512, 512], fill=COLOR_PRIMARY_GREEN)
+    draw.ellipse([100, 100, 412, 412], fill=COLOR_PRIMARY_ORANGE)
+    
+    # Draw fork and spoon icon
+    # Fork tines
+    draw.line([(180, 200), (180, 350)], fill=COLOR_WHITE, width=15)
+    draw.line([(240, 200), (240, 350)], fill=COLOR_WHITE, width=15)
+    draw.line([(300, 200), (300, 350)], fill=COLOR_WHITE, width=15)
+    
+    # Fork handle
+    draw.line([(240, 350), (240, 420)], fill=COLOR_WHITE, width=20)
+    
+    # Spoon
+    draw.ellipse([(330, 180), (400, 250)], fill=COLOR_LIGHT_ORANGE, outline=COLOR_WHITE, width=2)
+    draw.line([(365, 250), (365, 420)], fill=COLOR_WHITE, width=20)
+    
+    img.save('graphics/app_icon_512x512.png')
+    print("✅ Created: graphics/app_icon_512x512.png")
+
+def generate_feature_graphic():
+    """Generate feature graphic 1024x500."""
+    img = Image.new('RGB', (1024, 500), COLOR_LIGHT_GRAY)
+    draw = ImageDraw.Draw(img)
+    
+    # Background with gradient colors
+    for y in range(500):
+        ratio = y / 500
+        r = int(COLOR_PRIMARY_GREEN[0] * (1 - ratio) + COLOR_ACCENT_BLUE[0] * ratio)
+        g = int(COLOR_PRIMARY_GREEN[1] * (1 - ratio) + COLOR_ACCENT_BLUE[1] * ratio)
+        b = int(COLOR_PRIMARY_GREEN[2] * (1 - ratio) + COLOR_ACCENT_BLUE[2] * ratio)
+        draw.line([(0, y), (1024, y)], fill=(r, g, b))
+    
+    # Draw decorative circles
+    draw.ellipse([50, 50, 250, 250], fill=COLOR_PRIMARY_ORANGE, outline=COLOR_WHITE, width=3)
+    draw.ellipse([750, 250, 950, 450], fill=COLOR_LIGHT_ORANGE, outline=COLOR_WHITE, width=3)
+    
+    # Text
+    try:
+        font_large = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 60)
+        font_small = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 28)
+    except:
+        font_large = ImageFont.load_default()
+        font_small = ImageFont.load_default()
+    
+    draw.text((150, 180), "MyRecipeApp", fill=COLOR_WHITE, font=font_large)
+    draw.text((150, 260), "AI-Powered Recipe Management", fill=COLOR_LIGHT_ORANGE, font=font_small)
+    
+    img.save('graphics/feature_graphic_1024x500.png')
+    print("✅ Created: graphics/feature_graphic_1024x500.png")
+
+def generate_screenshot(num, title, subtitle, accent_color):
+    """Generate screenshot 1080x1920."""
+    img = Image.new('RGB', (1080, 1920), COLOR_LIGHT_GRAY)
+    draw = ImageDraw.Draw(img)
+    
+    # Status bar (dark)
+    draw.rectangle([0, 0, 1080, 80], fill=COLOR_DARK_GRAY)
+    
+    # Header
+    draw.rectangle([0, 80, 1080, 200], fill=accent_color)
+    
+    # Main content area (white)
+    draw.rectangle([0, 200, 1080, 1920], fill=COLOR_WHITE)
+    
+    try:
+        font_title = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 48)
+        font_subtitle = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 32)
+        font_text = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 24)
+    except:
+        font_title = ImageFont.load_default()
+        font_subtitle = ImageFont.load_default()
+        font_text = ImageFont.load_default()
+    
+    # Time in status bar
+    draw.text((50, 20), "9:41", fill=COLOR_WHITE, font=font_title)
+    
+    # Header text
+    draw.text((50, 100), "MyRecipeApp", fill=COLOR_WHITE, font=font_title)
+    
+    # Main title
+    draw.text((50, 250), title, fill=accent_color, font=font_title)
+    draw.text((50, 330), subtitle, fill=COLOR_DARK_GRAY, font=font_subtitle)
+    
+    # Content boxes
+    box_y = 450
+    for i in range(3):
+        draw.rectangle([50, box_y, 1030, box_y + 150], 
+                      fill=COLOR_LIGHT_GRAY, outline=accent_color, width=2)
+        draw.text((80, box_y + 40), f"Feature {i+1}", 
+                 fill=COLOR_DARK_GRAY, font=font_text)
+        box_y += 180
+    
+    # Bottom button
+    draw.rectangle([150, 1750, 930, 1850], fill=accent_color)
+    draw.text((450, 1770), "Get Started", fill=COLOR_WHITE, font=font_subtitle)
+    
+    img.save(f'graphics/screenshot_{num}_1080x1920.png')
+    print(f"✅ Created: graphics/screenshot_{num}_1080x1920.png")
+
+def main():
+    print("\n🎨 Generating MyRecipeApp Graphics...")
+    print("=" * 50)
+    
+    generate_app_icon()
+    generate_feature_graphic()
+    
+    generate_screenshot(1, "AI Recipe Extraction", "Convert any recipe text instantly", COLOR_PRIMARY_ORANGE)
+    generate_screenshot(2, "Multi-Timer Widget", "Manage multiple cooking timers", COLOR_ACCENT_BLUE)
+    generate_screenshot(3, "Recipe Management", "Organize all your recipes", COLOR_PRIMARY_GREEN)
+    
+    print("=" * 50)
+    print("✅ All graphics generated successfully!")
+    print("\n📁 Graphics created in: graphics/")
+    print("\n⚠️  Note: These are placeholder graphics for testing.")
+    print("   Use professional designs for actual Play Store submission.")
+    print("\n📖 See graphics/GRAPHICS_SPECIFICATIONS.md for requirements.\n")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add graphics specifications and placeholder generation script for Play Store.

## Changes
- Create `graphics/GRAPHICS_SPECIFICATIONS.md` with comprehensive requirements:
  - App icon (512×512 px PNG)
  - Feature graphic (1024×500 px landscape)
  - Screenshots (1080×1920 px or 1440×2560 px)
  - Design guidelines and brand color palette
  - Typography recommendations
  - Hosting options (Canva, Figma, professional designers)
  - Play Console upload instructions
  - Quality checklist

- Add `graphics/generate_graphics.py` Python script:
  - Automatically generates all placeholder graphics
  - Uses brand colors (orange, green, blue)
  - Professional layout with icons and text
  - Perfect for testing before professional design

- Add `graphics/README.md` quick start guide:
  - Installation and usage instructions
  - File organization overview
  - Links to specifications and resources

## Features
✅ Meets all Google Play Store requirements
✅ Brand-consistent color palette included
✅ Automated placeholder generation
✅ Clear design guidelines for professionals
✅ Links to design tools and resources
✅ Step-by-step Play Console instructions

## What's Included
- Professional specifications (not just placeholders)
- Python script for quick placeholder generation
- Design guidelines for custom graphics
- Quality checklist for submission
- Resource links (Canva, Figma, etc.)

## Usage
```bash
# Generate placeholder graphics
python graphics/generate_graphics.py

# Creates:
# - app_icon_512x512.png
# - feature_graphic_1024x500.png
# - screenshot_1_1080x1920.png (×3)
```

## Testing
- ✅ All 101 tests passing
- ✅ Security audit passing (0 vulnerabilities)
- ✅ Pre-commit checks passing

**Note:** This provides placeholders for development. Use professional designs for actual Play Store submission.

Closes #50