### PR TITLE
fix(#162): Fix AsyncStorage import in extractor services

### DIFF
--- a/MyRecipeApp/__tests__/instagramExtractorService.test.js
+++ b/MyRecipeApp/__tests__/instagramExtractorService.test.js
@@ -14,18 +14,17 @@ import {
   getCacheExpiration,
   analyzeInstagramError,
 } from '../services/instagramExtractorService';
-import { AsyncStorage } from 'react-native';
 
 // Mock AsyncStorage
-jest.mock('react-native', () => ({
-  AsyncStorage: {
-    getItem: jest.fn(),
-    setItem: jest.fn(),
-    removeItem: jest.fn(),
-    multiRemove: jest.fn(),
-    getAllKeys: jest.fn(),
-  },
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  multiRemove: jest.fn(),
+  getAllKeys: jest.fn(),
 }));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 describe('Instagram Extractor Service', () => {
   beforeEach(() => {

--- a/MyRecipeApp/__tests__/tiktokExtractorService.test.js
+++ b/MyRecipeApp/__tests__/tiktokExtractorService.test.js
@@ -13,18 +13,17 @@ import {
   getCacheExpiration,
   analyzeTikTokError,
 } from '../services/tiktokExtractorService';
-import { AsyncStorage } from 'react-native';
 
 // Mock AsyncStorage
-jest.mock('react-native', () => ({
-  AsyncStorage: {
-    getItem: jest.fn(),
-    setItem: jest.fn(),
-    removeItem: jest.fn(),
-    multiRemove: jest.fn(),
-    getAllKeys: jest.fn(),
-  },
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  multiRemove: jest.fn(),
+  getAllKeys: jest.fn(),
 }));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 describe('tiktokExtractorService', () => {
   beforeEach(() => {

--- a/MyRecipeApp/__tests__/websiteExtractorService.test.js
+++ b/MyRecipeApp/__tests__/websiteExtractorService.test.js
@@ -15,18 +15,17 @@ import {
   analyzeWebsiteError,
   validateRecipeData,
 } from '../services/websiteExtractorService';
-import { AsyncStorage } from 'react-native';
 
-// Mock AsyncStorage
-jest.mock('react-native', () => ({
-  AsyncStorage: {
-    getItem: jest.fn(),
-    setItem: jest.fn(),
-    removeItem: jest.fn(),
-    multiRemove: jest.fn(),
-    getAllKeys: jest.fn(),
-  },
+// Mock AsyncStorage (correct package)
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  multiRemove: jest.fn(),
+  getAllKeys: jest.fn(),
 }));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 // Simple URL key generator instead of Buffer-based
 const encodeUrl = (url) => {

--- a/MyRecipeApp/__tests__/youtubeExtractorService.test.js
+++ b/MyRecipeApp/__tests__/youtubeExtractorService.test.js
@@ -13,17 +13,14 @@ import {
   getCacheExpiration,
   analyzeTranscriptError,
 } from '../services/youtubeExtractorService';
-import { AsyncStorage } from 'react-native';
 
-// Mock AsyncStorage
-jest.mock('react-native', () => ({
-  AsyncStorage: {
-    getItem: jest.fn(),
-    setItem: jest.fn(),
-    removeItem: jest.fn(),
-    multiRemove: jest.fn(),
-    getAllKeys: jest.fn(),
-  },
+// Mock AsyncStorage (correct package)
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  multiRemove: jest.fn(),
+  getAllKeys: jest.fn(),
 }));
 
 // Mock axios for backend API calls
@@ -32,6 +29,7 @@ jest.mock('axios', () => ({
 }));
 
 import axios from 'axios';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 describe('youtubeExtractorService', () => {
   beforeEach(() => {

--- a/MyRecipeApp/services/instagramExtractorService.js
+++ b/MyRecipeApp/services/instagramExtractorService.js
@@ -4,7 +4,7 @@
  * Supports video download, metadata extraction, and recipe parsing
  */
 
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import apiClient from './apiClient';
 
 /**

--- a/MyRecipeApp/services/tiktokExtractorService.js
+++ b/MyRecipeApp/services/tiktokExtractorService.js
@@ -4,7 +4,7 @@
  * Supports video download, metadata extraction, and recipe parsing
  */
 
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import apiClient from './apiClient';
 
 /**

--- a/MyRecipeApp/services/websiteExtractorService.js
+++ b/MyRecipeApp/services/websiteExtractorService.js
@@ -4,7 +4,7 @@
  * Supports content parsing, recipe extraction, and metadata collection
  */
 
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import apiClient from './apiClient';
 
 /**

--- a/MyRecipeApp/services/youtubeExtractorService.js
+++ b/MyRecipeApp/services/youtubeExtractorService.js
@@ -8,7 +8,7 @@
  * - POST /api/transcribe - Extract and transcribe audio
  */
 
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import axios from 'axios';
 
 /**


### PR DESCRIPTION
## Fix YouTube Recipe Extraction AsyncStorage Import Error

Resolves #162

### Problem
YouTube recipe extraction was failing with the error:
```
AsyncStorage has been removed from react-native core. It can now be installed and imported from '@react-native-async-storage/async-storage'
```

### Root Cause
The extractor services were importing AsyncStorage from the deprecated location in the `react-native` package instead of the separate `@react-native-async-storage/async-storage` package.

### Solution
✅ Fixed AsyncStorage imports in all 4 extractor service files:
- `services/youtubeExtractorService.js`
- `services/tiktokExtractorService.js`
- `services/instagramExtractorService.js`
- `services/websiteExtractorService.js`

✅ Updated test files to mock the correct AsyncStorage package:
- `__tests__/youtubeExtractorService.test.js`
- `__tests__/tiktokExtractorService.test.js`
- `__tests__/instagramExtractorService.test.js`
- `__tests__/websiteExtractorService.test.js`

### Changes
Changed all imports from:
```javascript
import { AsyncStorage } from 'react-native';
```

To:
```javascript
import AsyncStorage from '@react-native-async-storage/async-storage';
```

Updated all jest mocks from:
```javascript
jest.mock('react-native', () => ({
  AsyncStorage: { /* ... */ }
}));
```

To:
```javascript
jest.mock('@react-native-async-storage/async-storage', () => ({
  // mock methods
}));
```

### Testing
✅ All 1126 tests passing
✅ Security audit: 0 vulnerabilities
✅ Pre-commit checks: passed
✅ Code coverage maintained at 88.93% statements

### Impact
- Fixes YouTube recipe extraction feature
- Enables TikTok, Instagram, and website recipe extraction
- Maintains backward compatibility with caching functionality
- No breaking changes to service APIs